### PR TITLE
fix: Update moviepy imports for compatibility with multiple versions

### DIFF
--- a/app/services/video_service.py
+++ b/app/services/video_service.py
@@ -33,7 +33,22 @@ def transcribe_video(video_path):
 
 from moviepy.video.VideoClip import TextClip
 from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
-from moviepy.video.fx import fadein, fadeout, speedx
+# Import effects using the correct moviepy structure
+try:
+    # Try newer moviepy import style first
+    from moviepy.video.fx.fadein import fadein
+    from moviepy.video.fx.fadeout import fadeout
+    from moviepy.video.fx.speedx import speedx
+except ImportError:
+    # Fallback to older import style
+    try:
+        from moviepy.video.fx import fadein, fadeout, speedx
+    except ImportError:
+        # If still failing, import as module
+        import moviepy.video.fx.all as vfx
+        fadein = vfx.fadein
+        fadeout = vfx.fadeout
+        speedx = vfx.speedx
 from scenedetect import open_video, SceneManager
 from scenedetect.detectors import ContentDetector
 


### PR DESCRIPTION
Fixed ImportError on Windows by updating effect imports to work with both older and newer versions of moviepy. Now tries multiple import strategies:
1. Newer style: from moviepy.video.fx.fadein import fadein
2. Older style: from moviepy.video.fx import fadein
3. Fallback: import moviepy.video.fx.all as vfx

This ensures compatibility across different moviepy installations.